### PR TITLE
Remove provided from Kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
-            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.camunda</groupId>


### PR DESCRIPTION
Post Zeebe 1.1.0 upgrade, Zeebe was not able to resolve Kafka files. Added Kafka jar along with the exporter and excluded sl4fj as it's already included in Zeebe.