### PR TITLE
Make the zeebe-export Kafka topic more configurable

### DIFF
--- a/src/main/java/hu/dpc/rt/kafkastreamer/exporter/KafkaExporterClient.java
+++ b/src/main/java/hu/dpc/rt/kafkastreamer/exporter/KafkaExporterClient.java
@@ -11,10 +11,7 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class KafkaExporterClient {
@@ -51,9 +48,9 @@ public class KafkaExporterClient {
 
         try {
             AdminClient adminClient = AdminClient.create(properties);
-            adminClient.createTopics(Arrays.asList(new NewTopic(configuration.kafkaTopic, 1, (short) 1)));
+            adminClient.createTopics(Arrays.asList(new NewTopic(configuration.kafkaTopic, Optional.ofNullable(configuration.kafkaTopicPartitions), Optional.ofNullable(configuration.kafkaTopicReplicationFactor).map(Integer::shortValue))));
             adminClient.close();
-            logger.info("created kafka topic {} successfully", configuration.kafkaTopic);
+            logger.info("created kafka topic {} with partitions {} and replication factor {} successfully", configuration.kafkaTopic, configuration.kafkaTopicPartitions, configuration.kafkaTopicReplicationFactor);
         } catch (Exception e) {
             logger.warn("Failed to create Kafka topic (it exists already?)", e);
         }

--- a/src/main/java/hu/dpc/rt/kafkastreamer/exporter/KafkaExporterConfiguration.java
+++ b/src/main/java/hu/dpc/rt/kafkastreamer/exporter/KafkaExporterConfiguration.java
@@ -35,7 +35,7 @@ public class KafkaExporterConfiguration {
         try {
             return Integer.parseInt(System.getenv(key));
         } catch (Exception e) {
-            logger.warn("Failed to parse env var {} with value {} as int", key, System.getenv(key));
+            logger.warn("Failed to parse env var '{}' with value '{}' as int", key, System.getenv(key));
             return null;
         }
     }

--- a/src/main/java/hu/dpc/rt/kafkastreamer/exporter/KafkaExporterConfiguration.java
+++ b/src/main/java/hu/dpc/rt/kafkastreamer/exporter/KafkaExporterConfiguration.java
@@ -7,11 +7,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.ObjectUtils;
 
+import java.util.Optional;
+
 public class KafkaExporterConfiguration {
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public String kafkaUrl;
     public String kafkaTopic;
+    public Integer kafkaTopicPartitions;
+    public Integer kafkaTopicReplicationFactor;
 
     public BulkConfiguration bulk = new BulkConfiguration();
 
@@ -22,7 +26,18 @@ public class KafkaExporterConfiguration {
         if (ObjectUtils.isEmpty(kafkaTopic)) {
             kafkaTopic = "zeebe-export";
         }
-        logger.info("DPC Kafka exporter configuration: {}", this);
+        kafkaTopicPartitions = parseEnvInt("ZEEBE_KAFKAEXPORT_TOPIC_PARTITIONS");
+        kafkaTopicReplicationFactor = parseEnvInt("ZEEBE_KAFKAEXPORT_TOPIC_REPLICATION_FACTOR");
+        logger.info("Kafka exporter configuration: {}", this);
+    }
+
+    private Integer parseEnvInt(String key) {
+        try {
+            return Integer.parseInt(System.getenv(key));
+        } catch (Exception e) {
+            logger.warn("Failed to parse env var {} with value {} as int", key, System.getenv(key));
+            return null;
+        }
     }
 
     @Override
@@ -30,6 +45,8 @@ public class KafkaExporterConfiguration {
         return "KafkaExporterConfiguration {" +
                 "kafkaUrl='" + kafkaUrl + '\'' +
                 ", kafkaTopic='" + kafkaTopic + '\'' +
+                ", kafkaTopicPartitions='" + kafkaTopicPartitions + '\'' +
+                ", kafkaTopicReplicationFactor='" + kafkaTopicReplicationFactor + '\'' +
                 '}';
     }
 


### PR DESCRIPTION
If the zeebe-export Kafka topic didn't exist at the component's startup, the component created it with the number of partitions and the replication factor set to 1. It caused some issues with clusters that required the number of minimum in-sync replicas set to 2 by default.

## Description

* Made the number of partitions and the replication factor configurable
* Changed the default replication factor from 1 to 3